### PR TITLE
Specify device map when loading boundary model

### DIFF
--- a/scripts/get_boundary.py
+++ b/scripts/get_boundary.py
@@ -21,8 +21,7 @@ def inference(args):
     # 1. Initialize the model.
     model_path = args.model_path
     model_name = get_model_name_from_path(model_path)
-    tokenizer, model, processor, context_len = load_pretrained_model(model_path, None, model_name)
-    model = model.to('cuda')
+    tokenizer, model, processor, context_len = load_pretrained_model(model_path, None, model_name, device='cuda', device_map={'': 'cuda:0'})
     conv_mode = 'llama_2'
 
     # 2. Visual preprocess (load & transform image or video).


### PR DESCRIPTION
## Summary
- load `get_boundary` model with explicit `device` and `device_map`
- remove redundant `.to('cuda')`

## Testing
- `python -m py_compile scripts/get_boundary.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2e6a057908327bdcb55c748a18a0d